### PR TITLE
Db setting

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+ENV.update YAML.load_file('config/secrets.yml')[Rails.env] rescue {}
+
 module Facebook
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,9 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-ENV.update YAML.load_file('config/secrets.yml')[Rails.env] rescue {}
+def ENV.update
+  YAML.load_file('config/secrets.yml')[Rails.env] if File.exist?('config/secrets.yml')
+end
 
 module Facebook
   class Application < Rails::Application


### PR DESCRIPTION
[背景]
http://www.techscore.com/blog/2012/10/26/how-to-manage-database-yml/
に従ってrails sやrake db:migrateするときに毎回
$ export DB_PASSWORD = 'hogehoge'
$ rails s
のようにするのが面倒

[やったこと]
application.rbでsecrets.ymlを読み込むようにして、secrets.ymlにパスワードを記載（secrets.ymlはgit管理外）