### PR TITLE
Recommend modify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,3 +115,6 @@ gem 'redis'
 
 # mailer delayed_job
 gem 'delayed_job_active_record'
+
+# run rake task once a day
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    chronic (0.10.2)
     chunky_png (1.3.8)
     codeclimate-engine-rb (0.4.0)
       virtus (~> 1.0)
@@ -377,6 +378,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -428,6 +431,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  whenever
 
 BUNDLED WITH
    1.14.0.pre.2

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -3,7 +3,9 @@ module Users
   class UsersController < BaseController
     def index
       @following_users = current_user.following_users
-      @unfollowing_users = current_user.recommended_user_ids.first(10).map { |id| User.find(id) }
+      ids = current_user.recommended_user_ids.first(10)
+      users = User.where(id: ids).index_by(&:id)
+      @unfollowing_users = ids.map { |id| users[id] }
       @follow_relationships_index_by_followee_user_id = \
         current_user.active_relationships.index_by(&:followee_user_id)
       @feed = Feed.new

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -3,7 +3,6 @@ module Users
   class UsersController < BaseController
     def index
       @following_users = current_user.following_users
-      # @unfollowing_users = User.where(id: current_user.recommended_user_ids)
       @unfollowing_users = current_user.recommended_user_ids.first(10).map { |id| User.find(id) }
       @follow_relationships_index_by_followee_user_id = \
         current_user.active_relationships.index_by(&:followee_user_id)

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -4,8 +4,7 @@ module Users
     def index
       @following_users = current_user.following_users
       # @unfollowing_users = User.where(id: current_user.recommended_user_ids)
-      @unfollowing_users = current_user.recommended_user_ids.map { |id| User.find(id) }
-      @unfollowing_users.delete(current_user)
+      @unfollowing_users = current_user.recommended_user_ids.first(10).map { |id| User.find(id) }
       @follow_relationships_index_by_followee_user_id = \
         current_user.active_relationships.index_by(&:followee_user_id)
       @feed = Feed.new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,4 +30,12 @@ module ApplicationHelper
       inner_product / (a * b) .to_f
     end
   end
+
+  def follow_links
+    if @unfollowing_users.present?
+      render 'follow_links'
+    else
+      content_tag :p, "Congratulations, you've followed all the people in FaceHook!"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,8 +31,8 @@ module ApplicationHelper
     end
   end
 
-  def follow_links
-    if @unfollowing_users.present?
+  def follow_links(unfollowing_users)
+    if unfollowing_users.present?
       render 'follow_links'
     else
       content_tag :p, "Congratulations, you've followed all the people in FaceHook!"

--- a/app/models/similarities_user.rb
+++ b/app/models/similarities_user.rb
@@ -1,5 +1,5 @@
 class SimilaritiesUser < ApplicationRecord
-  validates :similarity_id, presence: true
+  validates :similarity_id, presence: true, uniqueness: { scope: [:user_id] }
   validates :user_id, presence: true
   belongs_to :similarity
 end

--- a/app/models/similarities_user.rb
+++ b/app/models/similarities_user.rb
@@ -1,0 +1,5 @@
+class SimilaritiesUser < ApplicationRecord
+  validates :similarity_id, presence: true
+  validates :user_id, presence: true
+  belongs_to :similarity
+end

--- a/app/models/similarity.rb
+++ b/app/models/similarity.rb
@@ -1,0 +1,4 @@
+class Similarity < ApplicationRecord
+  validates :similarity, presence: true
+  has_many :similarities_users, dependent: :destroy
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,10 +49,14 @@ class User < ApplicationRecord
     # top_ten.keys
     # REDIS.zrevrangebyscore 'similarities', 1, 0, limit: [0, 10]
     current_user_similarity_ids = similarities_users.pluck(:similarity_id)
-    top_ten_similarity_ids = Similarity.where(id: current_user_similarity_ids) \
-                                       .order(similarity: :desc).first(10).pluck(:id)
-    SimilaritiesUser.where(similarity_id: top_ten_similarity_ids) \
-                    .where.not(user_id: id).pluck(:user_id)
+    if current_user_similarity_ids.present?
+      top_ten_similarity_ids = Similarity.where(id: current_user_similarity_ids) \
+                                         .order(similarity: :desc).first(10).pluck(:id)
+      SimilaritiesUser.where(similarity_id: top_ten_similarity_ids) \
+                      .where.not(user_id: id).pluck(:user_id)
+    else
+      FollowRelationship.group(:followee_user_id).order('count_followee_user_id desc').count(:followee_user_id).keys.first(10)
+    end
   end
 
   def self.redis

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,9 +49,9 @@ class User < ApplicationRecord
     # top_ten.keys
     # REDIS.zrevrangebyscore 'similarities', 1, 0, limit: [0, 10]
     current_user_similarity_ids = similarities_users.pluck(:similarity_id)
-    top_ten_similarity_ids = Similarity.find(current_user_similarity_ids) \
-                                       .order(:similarity).first(10).pluck(:id)
-    SimilaritiesUser.find(top_ten_similarity_ids).where.not(user_id: id).pluck(:user_id)
+    top_ten_similarity_ids = Similarity.where(id: current_user_similarity_ids) \
+                                       .order(similarity: :desc).first(10).pluck(:id)
+    SimilaritiesUser.where(similarity_id: top_ten_similarity_ids).where.not(user_id: id).pluck(:user_id)
   end
 
   def self.redis

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
   has_many :groups_users, dependent: :destroy
   has_many :group_posts, dependent: :destroy
   has_many :group_post_favorites, dependent: :destroy
+  has_many :similarities_users, dependent: :destroy
   mount_uploader :picture, PictureUploader
   validate :picture_size
   scope :notifiable, -> { where(notification_allowed: true) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
                                        .order('count_followee_user_id desc') \
                                        .count(:followee_user_id).keys
     end
+    # users who are already followed by current_user should never be recommended
     top_user_ids - FollowRelationship.where(follower_user_id: id).pluck(:followee_user_id)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
-# rubocop: disable AbcSize
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
@@ -42,16 +41,17 @@ class User < ApplicationRecord
     # user_ids = User.all.ids - [id]
     # similarities = {}
     # user_ids.each do |ui|
-      # similarities[ui] = cos_similarity(id, ui)
-      # REDIS.zadd 'similarities', cos_similarity(id, ui), ui
+    # similarities[ui] = cos_similarity(id, ui)
+    # REDIS.zadd 'similarities', cos_similarity(id, ui), ui
     # end
     # sorted = Hash[similarities.sort_by { |_k, v| -v }]
     # top_ten = Hash[*sorted.to_a.shift(10).flatten!]
     # top_ten.keys
     # REDIS.zrevrangebyscore 'similarities', 1, 0, limit: [0, 10]
-    current_users_similarity_ids = self.similarities_users.pluck(:similarity_id)
-    top_ten_similarity_ids = Similarity.find(similarity_ids).order(:similarity).first(10).pluck(:id)
-    
+    current_user_similarity_ids = similarities_users.pluck(:similarity_id)
+    top_ten_similarity_ids = Similarity.find(current_user_similarity_ids) \
+                                       .order(:similarity).first(10).pluck(:id)
+    SimilaritiesUser.find(top_ten_similarity_ids).where.not(user_id: id).pluck(:user_id)
   end
 
   def self.redis

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,16 +39,19 @@ class User < ApplicationRecord
   end
 
   def recommended_user_ids
-    user_ids = User.all.ids - [id]
-    similarities = {}
-    user_ids.each do |ui|
-      similarities[ui] = cos_similarity(id, ui)
+    # user_ids = User.all.ids - [id]
+    # similarities = {}
+    # user_ids.each do |ui|
+      # similarities[ui] = cos_similarity(id, ui)
       # REDIS.zadd 'similarities', cos_similarity(id, ui), ui
-    end
-    sorted = Hash[similarities.sort_by { |_k, v| -v }]
-    top_ten = Hash[*sorted.to_a.shift(10).flatten!]
-    top_ten.keys
+    # end
+    # sorted = Hash[similarities.sort_by { |_k, v| -v }]
+    # top_ten = Hash[*sorted.to_a.shift(10).flatten!]
+    # top_ten.keys
     # REDIS.zrevrangebyscore 'similarities', 1, 0, limit: [0, 10]
+    current_users_similarity_ids = self.similarities_users.pluck(:similarity_id)
+    top_ten_similarity_ids = Similarity.find(similarity_ids).order(:similarity).first(10).pluck(:id)
+    
   end
 
   def self.redis

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,8 @@ class User < ApplicationRecord
     current_user_similarity_ids = similarities_users.pluck(:similarity_id)
     top_ten_similarity_ids = Similarity.where(id: current_user_similarity_ids) \
                                        .order(similarity: :desc).first(10).pluck(:id)
-    SimilaritiesUser.where(similarity_id: top_ten_similarity_ids).where.not(user_id: id).pluck(:user_id)
+    SimilaritiesUser.where(similarity_id: top_ten_similarity_ids) \
+                    .where.not(user_id: id).pluck(:user_id)
   end
 
   def self.redis

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
@@ -38,16 +39,6 @@ class User < ApplicationRecord
   end
 
   def recommended_user_ids
-    # user_ids = User.all.ids - [id]
-    # similarities = {}
-    # user_ids.each do |ui|
-    # similarities[ui] = cos_similarity(id, ui)
-    # REDIS.zadd 'similarities', cos_similarity(id, ui), ui
-    # end
-    # sorted = Hash[similarities.sort_by { |_k, v| -v }]
-    # top_ten = Hash[*sorted.to_a.shift(10).flatten!]
-    # top_ten.keys
-    # REDIS.zrevrangebyscore 'similarities', 1, 0, limit: [0, 10]
     current_user_similarity_ids = similarities_users.pluck(:similarity_id)
     if current_user_similarity_ids.present?
       top_ten_similarity_ids = Similarity.where(id: current_user_similarity_ids) \
@@ -55,7 +46,8 @@ class User < ApplicationRecord
       SimilaritiesUser.where(similarity_id: top_ten_similarity_ids) \
                       .where.not(user_id: id).pluck(:user_id)
     else
-      FollowRelationship.group(:followee_user_id).order('count_followee_user_id desc').count(:followee_user_id).keys.first(10)
+      FollowRelationship.group(:followee_user_id).order('count_followee_user_id desc') \
+                        .count(:followee_user_id).keys.first(10)
     end
   end
 

--- a/app/services/similarity_create_service.rb
+++ b/app/services/similarity_create_service.rb
@@ -5,7 +5,6 @@ class SimilarityCreateService
     @similarity = similarity
   end
 
-
   def create_similarity
     a = Similarity.create(similarity: @similarity)
     SimilaritiesUser.create(similarity_id: a.id, user_id: @id_1)

--- a/app/services/similarity_create_service.rb
+++ b/app/services/similarity_create_service.rb
@@ -1,0 +1,18 @@
+class SimilarityCreateService
+  def initialize(id_1, id_2, similarity)
+    @id_1 = id_1
+    @id_2 = id_2
+    @similarity = similarity
+  end
+
+
+  def create_similarity
+    a = Similarity.create(similarity: @similarity)
+    SimilaritiesUser.create(similarity_id: a.id, user_id: @id_1)
+    SimilaritiesUser.create(similarity_id: a.id, user_id: @id_2)
+  end
+
+  private
+
+    attr_reader :id_1, :id_2, :similarity
+end

--- a/app/services/similarity_update_service.rb
+++ b/app/services/similarity_update_service.rb
@@ -12,7 +12,7 @@ class SimilarityUpdateService
     next unless similarity.update( \
       similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
   end
-  
+
   private
 
     attr_reader :id_1, :id_2

--- a/app/services/similarity_update_service.rb
+++ b/app/services/similarity_update_service.rb
@@ -1,0 +1,19 @@
+class SimilarityUpdateService
+  def initialize(id_1, id_2)
+    @id_1 = id_1
+    @id_2 = id_2
+  end
+
+  def update_similarity
+    array1 = SimilaritiesUser.where(user_id: @id_1).pluck(:similarity_id)
+    array2 = SimilaritiesUser.where(user_id: @id_2).pluck(:similarity_id)
+    next unless (array1 & array2).present?
+    similarity = Similarity.find((array1 & array2)[0])
+    next unless similarity.update( \
+      similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+  end
+  
+  private
+
+    attr_reader :id_1, :id_2
+end

--- a/app/views/users/users/_follow_links.html.slim
+++ b/app/views/users/users/_follow_links.html.slim
@@ -1,8 +1,8 @@
 p
-  | follow other users and explore the world with faceHook!
+  | Follow other users and explore the world with FaceHook!
 hr
 p
-  | users you're not following yet
+  | Users you're not following yet
 table.table.table-hover
   thead
     tr

--- a/app/views/users/users/_follow_links.html.slim
+++ b/app/views/users/users/_follow_links.html.slim
@@ -1,0 +1,21 @@
+p
+  | follow other users and explore the world with faceHook!
+hr
+p
+  | users you're not following yet
+table.table.table-hover
+  thead
+    tr
+      th Picture
+      th Name
+      th Born on
+      th colspan="3"
+  tbody
+    - @unfollowing_users.each do |unfollowing_user|
+      tr
+        td = image_tag unfollowing_user.picture.url(:thumb)
+        td = link_to unfollowing_user.name.to_s, users_user_path(unfollowing_user)
+        td = unfollowing_user.birth_date
+        td = link_to 'Follow',
+          users_follow_relationships_path(followee_user_id: unfollowing_user.id),
+          method: :post

--- a/app/views/users/users/index.html.slim
+++ b/app/views/users/users/index.html.slim
@@ -63,7 +63,7 @@
 
       hr
       p
-        | users you're following
+        | Users you're following
       table.table.table-hover
         thead
           tr

--- a/app/views/users/users/index.html.slim
+++ b/app/views/users/users/index.html.slim
@@ -59,28 +59,31 @@
       hr
 
     .col-md-5
-      p
-        | follow other users and explore the world with faceHook!
+      - if @unfollowing_users.present?
+        p
+          | follow other users and explore the world with faceHook!
 
-      hr
-      p
-        | users you're not following yet
-      table.table.table-hover
-        thead
-          tr
-            th Picture
-            th Name
-            th Born on
-            th colspan="3"
-        tbody
-          - @unfollowing_users.each do |unfollowing_user|
+        hr
+        p
+          | users you're not following yet
+        table.table.table-hover
+          thead
             tr
-              td = image_tag unfollowing_user.picture.url(:thumb)
-              td = link_to unfollowing_user.name.to_s, users_user_path(unfollowing_user)
-              td = unfollowing_user.birth_date
-              td = link_to 'Follow',
-                users_follow_relationships_path(followee_user_id: unfollowing_user.id),
-                method: :post
+              th Picture
+              th Name
+              th Born on
+              th colspan="3"
+          tbody
+            - @unfollowing_users.each do |unfollowing_user|
+              tr
+                td = image_tag unfollowing_user.picture.url(:thumb)
+                td = link_to unfollowing_user.name.to_s, users_user_path(unfollowing_user)
+                td = unfollowing_user.birth_date
+                td = link_to 'Follow',
+                  users_follow_relationships_path(followee_user_id: unfollowing_user.id),
+                  method: :post
+      - else
+        p Congratulations, you've followed all the people in FaceHook!
 
       hr
       p

--- a/app/views/users/users/index.html.slim
+++ b/app/views/users/users/index.html.slim
@@ -59,31 +59,7 @@
       hr
 
     .col-md-5
-      - if @unfollowing_users.present?
-        p
-          | follow other users and explore the world with faceHook!
-
-        hr
-        p
-          | users you're not following yet
-        table.table.table-hover
-          thead
-            tr
-              th Picture
-              th Name
-              th Born on
-              th colspan="3"
-          tbody
-            - @unfollowing_users.each do |unfollowing_user|
-              tr
-                td = image_tag unfollowing_user.picture.url(:thumb)
-                td = link_to unfollowing_user.name.to_s, users_user_path(unfollowing_user)
-                td = unfollowing_user.birth_date
-                td = link_to 'Follow',
-                  users_follow_relationships_path(followee_user_id: unfollowing_user.id),
-                  method: :post
-      - else
-        p Congratulations, you've followed all the people in FaceHook!
+      = follow_links
 
       hr
       p

--- a/app/views/users/users/index.html.slim
+++ b/app/views/users/users/index.html.slim
@@ -59,7 +59,7 @@
       hr
 
     .col-md-5
-      = follow_links
+      = follow_links(@unfollowing_users)
 
       hr
       p

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,6 @@ module Facebook
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.active_job.queue_adapter = :delayed_job
+    config.autoload_paths += %W(#{config.root}/app/services)
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,3 +24,7 @@ set :environment, :development
 every 1.day, at: '4:30 pm' do
   rake 'recommend:daily_update'
 end
+
+every 10.minutes do
+  rake 'recommend:hello'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,26 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+set :environment, :development
+
+every 1.day, at: '3:00 am' do
+  rake 'recommend:daily_update'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,7 +18,7 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
-
+set :output, 'log/crontab.log'
 set :environment, :development
 
 every 1.day, at: '3:00 am' do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,6 +21,6 @@
 set :output, 'log/crontab.log'
 set :environment, :development
 
-every 1.day, at: '3:00 am' do
+every 1.day, at: '4:30 pm' do
   rake 'recommend:daily_update'
 end

--- a/db/migrate/20170321115140_create_similarities.rb
+++ b/db/migrate/20170321115140_create_similarities.rb
@@ -1,0 +1,9 @@
+class CreateSimilarities < ActiveRecord::Migration[5.0]
+  def change
+    create_table :similarities do |t|
+      t.integer :similarity, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170321115553_create_similarities_users.rb
+++ b/db/migrate/20170321115553_create_similarities_users.rb
@@ -1,0 +1,10 @@
+class CreateSimilaritiesUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :similarities_users do |t|
+      t.integer :similarity_id, null: false
+      t.integer :user_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170322031811_change_datatype_similarity_of_similarities.rb
+++ b/db/migrate/20170322031811_change_datatype_similarity_of_similarities.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeSimilarityOfSimilarities < ActiveRecord::Migration[5.0]
+  def change
+    change_column :similarities, :similarity, :float, default: 0, null: false
+  end
+end

--- a/db/migrate/20170323074258_add_index_to_similarities_users.rb
+++ b/db/migrate/20170323074258_add_index_to_similarities_users.rb
@@ -1,0 +1,5 @@
+class AddIndexToSimilaritiesUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_index  :similarities_users, [:user_id, :similarity_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170321115553) do
+ActiveRecord::Schema.define(version: 20170322031811) do
 
   create_table "active_admin_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "namespace"
@@ -155,9 +155,9 @@ ActiveRecord::Schema.define(version: 20170321115553) do
   end
 
   create_table "similarities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "similarity", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.float    "similarity", limit: 24, default: 0.0, null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
   create_table "similarities_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170307064959) do
+ActiveRecord::Schema.define(version: 20170321115553) do
 
   create_table "active_admin_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "namespace"
@@ -152,6 +152,19 @@ ActiveRecord::Schema.define(version: 20170307064959) do
     t.string   "picture",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "similarities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "similarity", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "similarities_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "similarity_id", null: false
+    t.integer  "user_id",       null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170322031811) do
+ActiveRecord::Schema.define(version: 20170323074258) do
 
   create_table "active_admin_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "namespace"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20170322031811) do
     t.integer  "group_post_id", null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.index ["user_id", "group_post_id"], name: "index_group_post_favorites_on_user_id_and_group_post_id", unique: true, using: :btree
   end
 
   create_table "group_post_pictures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -126,6 +127,7 @@ ActiveRecord::Schema.define(version: 20170322031811) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_groups_users_on_group_id", using: :btree
+    t.index ["user_id", "group_id"], name: "index_groups_users_on_user_id_and_group_id", unique: true, using: :btree
     t.index ["user_id"], name: "index_groups_users_on_user_id", using: :btree
   end
 
@@ -165,6 +167,7 @@ ActiveRecord::Schema.define(version: 20170322031811) do
     t.integer  "user_id",       null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.index ["user_id", "similarity_id"], name: "index_similarities_users_on_user_id_and_similarity_id", unique: true, using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -11,6 +11,24 @@ namespace :recommend do
   end
 
   task daily_update: :environment do
+    # new users => new empty similarity
+    new_user_ids = User.where(created_at: 1.day.ago.all_day).ids
+    existing_user_ids = User.ids - new_user_ids
+    new_user_ids.each do |id_1|
+      existing_user_ids.each do |id_2|
+        a = Similarity.create(similarity: 0)
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+      end
+      new_user_ids.select { |item| item > id_1 }.each do |id_2|
+        a = Similarity.create(similarity: 0)
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+      end
+    end
+
+
+
     # new follow_relationships => update similarity score
     new_relationships = FollowRelationship.where(created_at: 1.day.ago.all_day)
     changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) | \
@@ -20,13 +38,15 @@ namespace :recommend do
       unchanged_user_ids.each do |id_2|
         array1 = SimilaritiesUser.where(user_id: id_1).pluck(:similarity_id)
         array2 = SimilaritiesUser.where(user_id: id_2).pluck(:similarity_id)
+        next unless (array1 & array2).present?
         similarity = Similarity.find((array1 & array2)[0])
         next unless similarity.update( \
           similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
-      changed_user_ids.where('id > ?', id_1).each do |id_2|
+      changed_user_ids.select { |item| item > id_1 }.each do |id_2|
         array1 = SimilaritiesUser.where(user_id: id_1).pluck(:similarity_id)
         array2 = SimilaritiesUser.where(user_id: id_2).pluck(:similarity_id)
+        next unless (array1 & array2).present?
         similarity = Similarity.find((array1 & array2)[0])
         next unless similarity.update( \
           similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -17,14 +17,16 @@ namespace :recommend do
     unchanged_user_ids = User.ids - changed_user_ids
     changed_user_ids.each do |id_1|
       unchanged_user_ids.each do |id_2|
-        a = Similarity.create(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+        array1 = SimilarityUser.where(user_id: id_1).pluck(:similarity_id) # user_idがaのsimilarity_id一覧
+        array2 = SimilarityUser.where(user_id: id_2).pluck(:similarity_id) # user_idがbのsimilarity_id一覧
+        similarity = Similarity.find((array1 & array2)[0])
+        next unless similarity.update(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
       changed_user_ids.where('id > ?', id_1).each do |id_2|
-        a = Similarity.create(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+        array1 = SimilarityUser.where(user_id: id_1).pluck(&:similarity_id) # user_idがaのsimilarity_id一覧
+        array2 = SimilarityUser.where(user_id: id_2).pluck(&:similarity_id) # user_idがbのsimilarity_id一覧
+        similarity = Similarity.find((array1 & array2)[0])
+        next unless similarity.update(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
     end
   end

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -27,8 +27,6 @@ namespace :recommend do
       end
     end
 
-
-
     # new follow_relationships => update similarity score
     new_relationships = FollowRelationship.where(created_at: 1.day.ago.all_day)
     changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) | \

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -11,7 +11,7 @@ namespace :recommend do
   end
 
   task daily_update: :environment do
-    new_relationships = FollowRelationship.where('created_at > ?', Time.zone.now - 1.day)
+    new_relationships = FollowRelationship.where(created_at: 1.day.ago.all_day)
     changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) & \
                        new_relationships.uniq.pluck(:followee_user_id)
     unchanged_user_ids = User.ids - changed_user_ids
@@ -24,8 +24,8 @@ namespace :recommend do
           similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
       changed_user_ids.where('id > ?', id_1).each do |id_2|
-        array1 = SimilarityUser.where(user_id: id_1).pluck(&:similarity_id)
-        array2 = SimilarityUser.where(user_id: id_2).pluck(&:similarity_id)
+        array1 = SimilarityUser.where(user_id: id_1).pluck(:similarity_id)
+        array2 = SimilarityUser.where(user_id: id_2).pluck(:similarity_id)
         similarity = Similarity.find((array1 & array2)[0])
         next unless similarity.update( \
           similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -17,16 +17,18 @@ namespace :recommend do
     unchanged_user_ids = User.ids - changed_user_ids
     changed_user_ids.each do |id_1|
       unchanged_user_ids.each do |id_2|
-        array1 = SimilarityUser.where(user_id: id_1).pluck(:similarity_id) # user_idがaのsimilarity_id一覧
-        array2 = SimilarityUser.where(user_id: id_2).pluck(:similarity_id) # user_idがbのsimilarity_id一覧
+        array1 = SimilarityUser.where(user_id: id_1).pluck(:similarity_id)
+        array2 = SimilarityUser.where(user_id: id_2).pluck(:similarity_id)
         similarity = Similarity.find((array1 & array2)[0])
-        next unless similarity.update(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+        next unless similarity.update( \
+          similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
       changed_user_ids.where('id > ?', id_1).each do |id_2|
-        array1 = SimilarityUser.where(user_id: id_1).pluck(&:similarity_id) # user_idがaのsimilarity_id一覧
-        array2 = SimilarityUser.where(user_id: id_2).pluck(&:similarity_id) # user_idがbのsimilarity_id一覧
+        array1 = SimilarityUser.where(user_id: id_1).pluck(&:similarity_id)
+        array2 = SimilarityUser.where(user_id: id_2).pluck(&:similarity_id)
         similarity = Similarity.find((array1 & array2)[0])
-        next unless similarity.update(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+        next unless similarity.update( \
+          similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
     end
   end

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -3,9 +3,9 @@ namespace :recommend do
   task start_from_scratch: :environment do
     User.ids.sort.each do |id_1|
       User.where('id > ?', id_1).ids.each do |id_2|
-        a = Similarity.create(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+        similarity = ApplicationController.helpers.cos_similarity(id_1, id_2)
+        similarity_create_service = SimilarityCreateService.new(id_1, id_2, similarity)
+        similarity_create_service.create_similarity
       end
     end
   end
@@ -16,14 +16,12 @@ namespace :recommend do
     existing_user_ids = User.ids - new_user_ids
     new_user_ids.each do |id_1|
       existing_user_ids.each do |id_2|
-        a = Similarity.create(similarity: 0)
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+        similarity_create_service = SimilarityCreateService.new(id_1, id_2, 0)
+        similarity_create_service.create_similarity
       end
       new_user_ids.select { |item| item > id_1 }.each do |id_2|
-        a = Similarity.create(similarity: 0)
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
-        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+        similarity_create_service = SimilarityCreateService.new(id_1, id_2, 0)
+        similarity_create_service.create_similarity
       end
     end
 

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -11,25 +11,36 @@ namespace :recommend do
   end
 
   task daily_update: :environment do
+
+
+    # new follow_relationships => update similarity score
     new_relationships = FollowRelationship.where(created_at: 1.day.ago.all_day)
-    changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) & \
+    changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) | \
                        new_relationships.uniq.pluck(:followee_user_id)
     unchanged_user_ids = User.ids - changed_user_ids
     changed_user_ids.each do |id_1|
       unchanged_user_ids.each do |id_2|
-        array1 = SimilarityUser.where(user_id: id_1).pluck(:similarity_id)
-        array2 = SimilarityUser.where(user_id: id_2).pluck(:similarity_id)
+        array1 = SimilaritiesUser.where(user_id: id_1).pluck(:similarity_id)
+        array2 = SimilaritiesUser.where(user_id: id_2).pluck(:similarity_id)
         similarity = Similarity.find((array1 & array2)[0])
         next unless similarity.update( \
           similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
       changed_user_ids.where('id > ?', id_1).each do |id_2|
-        array1 = SimilarityUser.where(user_id: id_1).pluck(:similarity_id)
-        array2 = SimilarityUser.where(user_id: id_2).pluck(:similarity_id)
+        array1 = SimilaritiesUser.where(user_id: id_1).pluck(:similarity_id)
+        array2 = SimilaritiesUser.where(user_id: id_2).pluck(:similarity_id)
         similarity = Similarity.find((array1 & array2)[0])
         next unless similarity.update( \
           similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
       end
     end
+  end
+
+  task hoge: :environment do
+    puts 'hello world'
+  end
+
+  task hello: :environment do
+
   end
 end

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -1,0 +1,2 @@
+namespace :recommend do
+end

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -11,8 +11,6 @@ namespace :recommend do
   end
 
   task daily_update: :environment do
-
-
     # new follow_relationships => update similarity score
     new_relationships = FollowRelationship.where(created_at: 1.day.ago.all_day)
     changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) | \
@@ -41,6 +39,5 @@ namespace :recommend do
   end
 
   task hello: :environment do
-
   end
 end

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -1,2 +1,31 @@
 namespace :recommend do
+  desc 'calculate recommended users for each user from follow relationships'
+  task start_from_scratch: :environment do
+    User.ids.sort.each do |id_1|
+      User.where('id > ?', id_1).ids.each do |id_2|
+        a = Similarity.create(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+      end
+    end
+  end
+
+  task daily_update: :environment do
+    new_relationships = FollowRelationship.where('created_at > ?', Time.now - 1.days)
+    changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) & \
+      new_relationships.uniq.pluck(:followee_user_id)
+    unchanged_user_ids = User.ids - changed_user_ids
+    changed_user_ids.each do |id_1|
+      unchanged_user_ids.each do |id_2|
+        a = Similarity.create(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+      end
+      changed_user_ids.where('id > ?', id_1).each do |id_2|
+        a = Similarity.create(similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_1)
+        SimilaritiesUser.create(similarity_id: a.id, user_id: id_2)
+      end
+    end
+  end
 end

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -32,20 +32,12 @@ namespace :recommend do
     unchanged_user_ids = User.ids - changed_user_ids
     changed_user_ids.each do |id_1|
       unchanged_user_ids.each do |id_2|
-        array1 = SimilaritiesUser.where(user_id: id_1).pluck(:similarity_id)
-        array2 = SimilaritiesUser.where(user_id: id_2).pluck(:similarity_id)
-        next unless (array1 & array2).present?
-        similarity = Similarity.find((array1 & array2)[0])
-        next unless similarity.update( \
-          similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+        similarity_update_service = SimilarityUpdateService.new(id_1, id_2)
+        similarity_update_service.update_similarity
       end
       changed_user_ids.select { |item| item > id_1 }.each do |id_2|
-        array1 = SimilaritiesUser.where(user_id: id_1).pluck(:similarity_id)
-        array2 = SimilaritiesUser.where(user_id: id_2).pluck(:similarity_id)
-        next unless (array1 & array2).present?
-        similarity = Similarity.find((array1 & array2)[0])
-        next unless similarity.update( \
-          similarity: ApplicationController.helpers.cos_similarity(id_1, id_2))
+        similarity_update_service = SimilarityUpdateService.new(id_1, id_2)
+        similarity_update_service.update_similarity
       end
     end
   end

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -11,9 +11,9 @@ namespace :recommend do
   end
 
   task daily_update: :environment do
-    new_relationships = FollowRelationship.where('created_at > ?', Time.now - 1.days)
+    new_relationships = FollowRelationship.where('created_at > ?', Time.zone.now - 1.day)
     changed_user_ids = new_relationships.uniq.pluck(:follower_user_id) & \
-      new_relationships.uniq.pluck(:followee_user_id)
+                       new_relationships.uniq.pluck(:followee_user_id)
     unchanged_user_ids = User.ids - changed_user_ids
     changed_user_ids.each do |id_1|
       unchanged_user_ids.each do |id_2|

--- a/lib/tasks/recommend.rake
+++ b/lib/tasks/recommend.rake
@@ -57,5 +57,6 @@ namespace :recommend do
   end
 
   task hello: :environment do
+    puts Time.current
   end
 end


### PR DESCRIPTION
- Similaritiesテーブル、Similarities_usersテーブル
- rake task
①recommend: start_from_scratch
  既存のユーザーとフォロー関係より、similaritiesテーブルを一から構築する（createで入れる）
②recommend: daily_update
  毎日午前3時に、その前日にできたフォロー関係を元にsimilaritiesテーブルの値を書き換える（新たにフォローしたorされた人が関わるところだけ書き換える）
- user.rbのrecommended_user_idsは、similarityの高い順にuser全員を並べる
- 新規ユーザーなどでフォロー関係がなく、類似度計算しても0になる場合は、フォロワーが多い人から順に10人オススメする
- レコメンドリスト上のユーザーがフォローされたら、リストの中で次の人を出して10人オススメできるようにする
- 10人以下の場合（フォローしすぎてほぼ全員フォローした場合）、0人でなければオススメする
- 全員フォローしてしまった場合、オススメしようがないのでCongraturationsメッセージを出す

まだまだおすすめする人がいるときのビューは特に変更なし：
<img width="1280" alt="screen shot 2017-03-23 at 17 11 26" src="https://cloud.githubusercontent.com/assets/15964061/24237969/ea234ece-0feb-11e7-8536-3c1679f6cf54.png">

もう全員フォローしてしまった場合は、Congraturations(右上）
<img width="1280" alt="screen shot 2017-03-23 at 17 12 21" src="https://cloud.githubusercontent.com/assets/15964061/24237970/ea26bef6-0feb-11e7-9f35-5a3ce3d90227.png">
