### PR TITLE
user should not be deleted

### DIFF
--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -46,12 +46,3 @@
             label: 'check if you want to receive emails upon replies, likes to your posts'
         .actions
           = f.primary 'Update'
-      h3
-        | Cancel my account
-      p
-        | Unhappy?
-        = button_to 'Cancel my account',
-          registration_path(resource_name),
-          data: { confirm: 'Are you sure?' },
-          method: :delete,
-          class: 'btn btn-primary'


### PR DESCRIPTION
feedなどの投稿系は、「言ったことを言わなかったことにされても困る」みたいな思想で、admin以外削除できず、編集も公開度のみとしていた（自分の投稿であれば、機密などで送る相手を間違えることもあるだろうし、公開度を自分だけにするという選択肢はある）。

しかし、ユーザーそのものを消すことはできてしまっていて、当然その際は投稿も全て消せてしまうので、ユーザーそのものを（ユーザー自ら）消すことができないようにした。

変更前
<img width="1280" alt="screen shot 2017-03-23 at 16 58 27" src="https://cloud.githubusercontent.com/assets/15964061/24237535/04845634-0fea-11e7-9827-8dc7d6e9a543.png">


変更後
<img width="1280" alt="screen shot 2017-03-23 at 16 57 49" src="https://cloud.githubusercontent.com/assets/15964061/24237534/0483505e-0fea-11e7-9bd7-8a9864efd82c.png">

