### PR TITLE
can reply to my own feed, can't follow yourself

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
               method: :delete,
               data: { confirm: 'Unfollow this person?', disable_with: 'in progress...' },
               class: 'btn btn-primary'
-    else
+    elsif user != current_user
       link_to 'Follow', users_follow_relationships_path(followee_user_id: user.id),
               method: :post,
               data: { disable_with: 'in progress...' },

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -11,8 +11,8 @@ class Feed < ApplicationRecord
 
   def repliable_by?(replying_user)
     return true if privacy == 'share_with_all'
-    return false if privacy == 'share_with_only_me'
     return true if user == replying_user
+    return false if privacy == 'share_with_only_me'
     privacy == 'share_with_follower' && user.following?(replying_user)
   end
 end


### PR DESCRIPTION
①feedに対するreplyにおいて、

- 自分で自分の投稿に返信しようとした
- 元の投稿がshare_with_only_meだった

場合、feed.repliable_by?の設定（順序）がまずく、404に飛んでいたのを直した

②Users#showで自分のプロフィールも見られるが、ここで自分をフォローするボタンがあったのでヘルパーいじって消すようにした